### PR TITLE
Downgrade Raml2Obj

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "nunjucks": "*",
     "pluralize": "*",
     "pretty-data": "^0.40.0",
-    "raml2obj": "*",
+    "raml2obj": "^3.*",
     "walk": "*"
   },
   "homepage": "https://github.com/iQmetrix/api-documentation",


### PR DESCRIPTION
Raml2Obj needs to be downgraded as 4.x removes RAML 0.8 support